### PR TITLE
/ipfs code mismatch

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -7,7 +7,7 @@ code,	size,	name
 132,	16,	sctp
 301,	0,	udt
 302,	0,	utp
-421,	V,	ipfs
+42,	V,	ipfs
 480,	0,	http
 443,	0,	https
 444,	96,	onion


### PR DESCRIPTION
This is taken from https://github.com/multiformats/js-multiaddr/blob/master/src/protocols.csv#L10. I am not sure which is more accurate, this or that file. Any idea where to find the source of truth for this address?

Perhaps we should collapse the two protocols list, or import multiaddr's list into js-multiaddr directly.
