### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
 ## Implementations
 
-- [js-multiaddr](https://github.com/jbenet/js-multiaddr) - stable
-- [go-multiaddr](https://github.com/jbenet/go-multiaddr) - stable
+- [js-multiaddr](https://github.com/multiformats/js-multiaddr) - stable
+- [go-multiaddr](https://github.com/multiformats/go-multiaddr) - stable
 - [java-multiaddr](https://github.com/ipfs/java-ipfs-api) - stable
 - [hs-multiaddr](https://github.com/basile-henry/hs-multiaddr) - draft
 - [py-multiaddr](https://github.com/sbuss/py-multiaddr) - alpha
-- [rust-multiaddr](https://github.com/Dignifiedquire/rust-multiaddr) - draft
+- [rust-multiaddr](https://github.com/multiformats/rust-multiaddr) - draft
 
 ## What is multiaddr?
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/Dignifiedquire/rust-multiaddr | https://github.com/multiformats/rust-multiaddr 
https://github.com/jbenet/go-multiaddr | https://github.com/multiformats/go-multiaddr 
https://github.com/jbenet/js-multiaddr | https://github.com/multiformats/js-multiaddr 
