### PR TITLE
[DISCUSSION] Add mediachain protocol code

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -8,6 +8,7 @@ code,	size,	name
 301,	0,	udt
 302,	0,	utp
 421,	V,	ipfs
+432,	V,	p2p
 480,	0,	http
 443,	0,	https
 444,	96,	onion


### PR DESCRIPTION
Following up on discussion [here](https://github.com/ipfs/pm/issues/236#issuecomment-256764454), I thought doing this via PR would be most illustrative.

The goal is to add support for well-formed mediachain multiaddrs, which I am picturing as

```
/ip4/99.69.16.78/tcp/4001/mc/QmfWapjgngSkeaA5B34YaYGdVPNocUP72hMoCmosdJVzoK
```


Questions brought up about this approach in IRC and elsewhere:

* what's the grammar for multiaddr? `$protocol/$data` tuples?
* should this be `/secio/QmfWapjgngSkeaA5B34YaYGdVPNocUP72hMoCmosdJVzoK/mc` instead? why isn't IPFS  `/secio/QmfWapjgngSkeaA5B34YaYGdVPNocUP72hMoCmosdJVzoK/ipfs`? is the commonly used `/ipfs/Q...` form a kind of alias/shorthand?
* is this the wrong approach? should we instead be registering a multistream protocol (as per [this](https://github.com/ipfs/pm/issues/236#issuecomment-257146952) comment by @diasdavid)? how should we go about implementing this? if we do choose multistream protocol approach, how should we refer to our nodes so it's clear that it's one of ours (i.e. equivalent of `http://...` for `/http/w3c.org/http/2`)?

I'm beginning to think that we *do* want a multistream protocol on top of secio transport, but I don't understand the relationship sufficiently to make a judgement. FWIW our nodes do not currently support bitswap (though supporting this is a long-term goal).