### PR TITLE
the Java implementation of Multiaddr has been split out of java-ipfs-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ https://github.com/jbenet/random-ideas/issues/11
 
 - [js-multiaddr](https://github.com/multiformats/js-multiaddr) - stable
 - [go-multiaddr](https://github.com/multiformats/go-multiaddr) - stable
-- [java-multiaddr](https://github.com/ipfs/java-ipfs-api) - stable
+- [java-multiaddr](https://github.com/multiformats/java-multiaddr) - stable
 - [hs-multiaddr](https://github.com/basile-henry/hs-multiaddr) - draft
 - [py-multiaddr](https://github.com/sbuss/py-multiaddr) - alpha
 - [rust-multiaddr](https://github.com/multiformats/rust-multiaddr) - draft


### PR DESCRIPTION
Update the documentation to correctly indicate the location of the Java implementation.