### PR TITLE
Change /ip6 to variable-length

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -3,7 +3,7 @@ code,	size,	name
 6,	16,	tcp
 17,	16,	udp
 33,	16,	dccp
-41,	128,	ip6
+41,	V,	ip6
 132,	16,	sctp
 301,	0,	udt
 302,	0,	utp


### PR DESCRIPTION
IPv6 addresses have a maximum size, but they can be shortened under certain circumstances, e.g. null-bytes can be omitted.

I know at least js-multiaddr and go-multiaddr permit variable-length /ip6 addresses anyhow, and also I'm not sure anything is actually paying attention to the sizes defined in protocols.csv :)