### PR TITLE
Add /dns, /wss, /relay, /p2p protocol codes

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -14,15 +14,14 @@ code,	size,	name,	comment
 420,	V,	p2p,	preferred over /ipfs
 421,	V,	ipfs,	equal to /p2p
 444,	96,	onion
-450,	V,	relay,	reserved for near-future use
 480,	0,	http
 443,	0,	https
 477,	0,	ws
 478,	0,	wss
 275,	0,	libp2p-webrtc-star
 276,	0,	libp2p-webrtc-direct
+290,	V,	libp2p-circuit-relay
 
 16383,	V,	exp-dns,	experimental /dns
 16382,	V,	exp-dns4,	experimental /dns4
 16381,	V,	exp-dns6,	experimental /dns6
-16380,	V,	exp-relay,	experimental /relay

--- a/protocols.csv
+++ b/protocols.csv
@@ -1,9 +1,11 @@
-code,	size,	name
+code,	size,	name, comment
 4,	32,	ip4
 6,	16,	tcp
 17,	16,	udp
 33,	16,	dccp
 41,	128,	ip6
+53,  V, dns, reserved for future use
+531, V, dns-exp, experimental /dns
 132,	16,	sctp
 301,	0,	udt
 302,	0,	utp
@@ -11,5 +13,8 @@ code,	size,	name
 480,	0,	http
 443,	0,	https
 444,	96,	onion
+450,  V,  relay, reserver for future use (preliminary name)
+451,  V,  relay-exp, experimental /relay
 477, 0, ws
+478, 0, wss
 275, 0, libp2p-webrtc-star

--- a/protocols.csv
+++ b/protocols.csv
@@ -1,20 +1,27 @@
-code,	size,	name, comment
+code,	size,	name,	comment
 4,	32,	ip4
 6,	16,	tcp
 17,	16,	udp
 33,	16,	dccp
 41,	128,	ip6
-53,  V, dns, reserved for future use
-531, V, dns-exp, experimental /dns
+53,	V,	dns,	reserved for near-future use
+54,	V,	dns4,	reserved for near-future use
+55,	V,	dns6,	reserved for near-future use
 132,	16,	sctp
 301,	0,	udt
 302,	0,	utp
-421,	V,	ipfs
+400,	V,	unix
+420,	V,	p2p,	preferred over /ipfs
+421,	V,	ipfs,	equal to /p2p
+444,	96,	onion
+450,	V,	relay,	reserved for near-future use
 480,	0,	http
 443,	0,	https
-444,	96,	onion
-450,  V,  relay, reserver for future use (preliminary name)
-451,  V,  relay-exp, experimental /relay
-477, 0, ws
-478, 0, wss
-275, 0, libp2p-webrtc-star
+477,	0,	ws
+478,	0,	wss
+275,	0,	libp2p-webrtc-star
+
+16383,	V,	exp-dns,	experimental /dns
+16382,	V,	exp-dns4,	experimental /dns4
+16381,	V,	exp-dns6,	experimental /dns6
+16380,	V,	exp-relay,	experimental /relay

--- a/protocols.csv
+++ b/protocols.csv
@@ -20,6 +20,7 @@ code,	size,	name,	comment
 477,	0,	ws
 478,	0,	wss
 275,	0,	libp2p-webrtc-star
+276,	0,	libp2p-webrtc-direct
 
 16383,	V,	exp-dns,	experimental /dns
 16382,	V,	exp-dns4,	experimental /dns4


### PR DESCRIPTION
Also add a fourth column, for comments.

- We'll be using the experimental /dns-exp protocol for now, as per #22. Once we're sure it's right, we'll make it into /dns.
- Same procedure for /relay, where in addition to the semantics, we're not even sure about the name.
- /wss on the other hand is pretty straightforward.