### PR TITLE
Settle on /dns4 and /dns6

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -4,9 +4,9 @@ code,	size,	name,	comment
 17,	16,	udp
 33,	16,	dccp
 41,	128,	ip6
-53,	V,	dns,	reserved for near-future use
-54,	V,	dns4,	reserved for near-future use
-55,	V,	dns6,	reserved for near-future use
+53,	V,	dns,	reserved
+54,	V,	dns4
+55,	V,	dns6
 132,	16,	sctp
 301,	0,	udt
 302,	0,	utp
@@ -21,7 +21,3 @@ code,	size,	name,	comment
 275,	0,	libp2p-webrtc-star
 276,	0,	libp2p-webrtc-direct
 290,	V,	libp2p-circuit-relay
-
-16383,	V,	exp-dns,	experimental /dns
-16382,	V,	exp-dns4,	experimental /dns4
-16381,	V,	exp-dns6,	experimental /dns6


### PR DESCRIPTION
tl;dr this PR removes the "experimental" protocols like /exp-dns.

David brought up good points against introducing multiaddr protocols with and "experimental" prefix in multiformats/js-multiaddr#39:

> I'm feeling that is going to bite us, in the same way that today we have `X-` HTTP headers everywhere because the rationale was "We are going to try this and then remove it", in reallity what happen is that so many tools started checking for the `X-` specifically, that they never got removed. 
> 
> See: https://tools.ietf.org/html/rfc6648
> tl;dr; in the answer here: http://stackoverflow.com/questions/3561381/custom-http-headers-naming-conventions
> 
> ```
> 3. Recommendations for Creators of New Parameters
> 
> ...
> 
> SHOULD NOT prefix their parameter names with "X-" or similar constructs.
> 4. Recommendations for Protocol Designers
> 
> ...
> 
> SHOULD NOT prohibit parameters with an "X-" prefix or similar constructs from being registered.
> MUST NOT stipulate that a parameter with an "X-" prefix or similar constructs needs to be understood as unstandardized.
> MUST NOT stipulate that a parameter without an "X-" prefix or similar constructs needs to be understood as standardized.
> ```
> 
> Right now, `multiaddrs with DNS` are just used to be passed around, to be announce and to be used for things like the WebSockets dialing to the Signalling Server on WebRTC-Star, I've avoided implementing the `.resolve` method for names as it is not directly a need for the current sprint and I agree with you, that shed will get some more coats of paint. 

I now think we should settle on /dns4 and /dns6 because of the above, and because they carry less complexity than /dns:

- They do unambiguously address a specific listener. With /dns, there would need to be a mechanism like RFC6555 to decide betwen ip4 and ip6. This reliefs us of most of the immaturatiy risk that was motivation for coming up with the "exp-" protocols.
- You know which kind of multiaddrs the `resolve()` step will yield: . With /dns, you don't know whether your libp2p stack actually supports the multiaddr, until after you've resolved it.

And in addition to this, we still keep /dns free for future uses :)