### PR TITLE
Update rust-multiaddr to beta state

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ https://github.com/jbenet/random-ideas/issues/11
 - [java-multiaddr](https://github.com/multiformats/java-multiaddr) - stable
 - [hs-multiaddr](https://github.com/basile-henry/hs-multiaddr) - draft
 - [py-multiaddr](https://github.com/sbuss/py-multiaddr) - alpha
-- [rust-multiaddr](https://github.com/multiformats/rust-multiaddr) - draft
+- [rust-multiaddr](https://github.com/multiformats/rust-multiaddr) - beta
 - [cs-multiaddress](https://github.com/tabrath/cs-multiaddress) - alpha
 - [net-ipfs-core](https://github.com/richardschneider/net-ipfs-core) - stable
 


### PR DESCRIPTION
With the new `0.2.0` all important address types are supported