### PR TITLE
Make /p2p into an alias for /ipfs

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -12,8 +12,8 @@ code,	size,	name,	comment
 301,	0,	udt,
 302,	0,	utp,
 400,	V,	unix,
-420,	V,	p2p,	preferred over /ipfs
-421,	V,	ipfs,	equal to /p2p
+421,	V,	p2p,	preferred over /ipfs
+421,	V,	ipfs,	backwards compatibility, equivalent to /p2p
 444,	96,	onion,
 460,	0,	quic,
 480,	0,	http,


### PR DESCRIPTION
In order to finally upgrade from using /ipfs everywhere to using /p2p as we should be, we need to make /p2p be an alias of /ipfs so that the upgrade path can happen easily.