### PR TITLE
Fix protocols.csv to be a properly formatted csv file

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -13,7 +13,7 @@ code,	size,	name,	comment
 302,	0,	utp,
 400,	V,	unix,
 421,	V,	p2p,	preferred over /ipfs
-421,	V,	ipfs,	""backwards compatibility, equivalent to /p2p""
+421,	V,	ipfs,	"backwards compatibility\, equivalent to /p2p"
 444,	96,	onion,
 460,	0,	quic,
 480,	0,	http,

--- a/protocols.csv
+++ b/protocols.csv
@@ -13,7 +13,7 @@ code,	size,	name,	comment
 302,	0,	utp,
 400,	V,	unix,
 421,	V,	p2p,	preferred over /ipfs
-421,	V,	ipfs,	"backwards compatibility\, equivalent to /p2p"
+421,	V,	ipfs,	backwards compatibility; equivalent to /p2p
 444,	96,	onion,
 460,	0,	quic,
 480,	0,	http,

--- a/protocols.csv
+++ b/protocols.csv
@@ -13,7 +13,7 @@ code,	size,	name,	comment
 302,	0,	utp,
 400,	V,	unix,
 421,	V,	p2p,	preferred over /ipfs
-421,	V,	ipfs,	backwards compatibility\, equivalent to /p2p
+421,	V,	ipfs,	""backwards compatibility, equivalent to /p2p""
 444,	96,	onion,
 460,	0,	quic,
 480,	0,	http,

--- a/protocols.csv
+++ b/protocols.csv
@@ -13,7 +13,7 @@ code,	size,	name,	comment
 302,	0,	utp,
 400,	V,	unix,
 421,	V,	p2p,	preferred over /ipfs
-421,	V,	ipfs,	"backwards compatibility, equivalent to /p2p"
+421,	V,	ipfs,	backwards compatibility\, equivalent to /p2p
 444,	96,	onion,
 460,	0,	quic,
 480,	0,	http,

--- a/protocols.csv
+++ b/protocols.csv
@@ -13,7 +13,7 @@ code,	size,	name,	comment
 302,	0,	utp,
 400,	V,	unix,
 421,	V,	p2p,	preferred over /ipfs
-421,	V,	ipfs,	backwards compatibility, equivalent to /p2p
+421,	V,	ipfs,	"backwards compatibility, equivalent to /p2p"
 444,	96,	onion,
 460,	0,	quic,
 480,	0,	http,


### PR DESCRIPTION
I couldn't figure out how github was parsing the csv files so I gave up and just changed the "," to a ";"