### PR TITLE
protocols.csv: Add "ip6%" multiaddr (IPv6 with zone ID)

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -1,10 +1,11 @@
-code,	size,	name,	comment
+code,	size,	name,		comment
 4,	32,	ip4,
 6,	16,	tcp,
 17,	16,	udp,
 33,	16,	dccp,
 41,	128,	ip6,
-53,	V,	dns,	reserved
+42,	V,	ip6zone,	rfc4007 IPv6 zone
+53,	V,	dns,		reserved
 54,	V,	dns4,
 55,	V,	dns6,
 56,	V,	dnsaddr,
@@ -12,8 +13,8 @@ code,	size,	name,	comment
 301,	0,	udt,
 302,	0,	utp,
 400,	V,	unix,
-421,	V,	p2p,	preferred over /ipfs
-421,	V,	ipfs,	backwards compatibility; equivalent to /p2p
+421,	V,	p2p,		preferred over /ipfs
+421,	V,	ipfs,		backwards compatibility; equivalent to /p2p
 444,	96,	onion,
 460,	0,	quic,
 480,	0,	http,


### PR DESCRIPTION
This is a generalization of the "ip6" multiaddr which accepts an
optional zone ID as specified in [rfc4007].

[rfc4007] https://tools.ietf.org/html/rfc4007

---

One probably controversial point is that I'm using a non alphanumeric character ('%') in the protocol string. I'll be happy to change it to a 'z' if there is the slightest objection.

See also:
- https://github.com/mwnx/go-multiaddr/tree/ip6z
- https://github.com/mwnx/go-multiaddr-net/tree/ip6z
- https://github.com/mwnx/multicodec/tree/ip6z