### PR TITLE
RFC: Add a memory protocol

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -24,3 +24,4 @@ code,	size,	name,	comment
 275,	0,	p2p-webrtc-star,
 276,	0,	p2p-webrtc-direct,
 290,	0,	p2p-circuit,
+777,	0,	memory,


### PR DESCRIPTION
In rust-libp2p, for unit testing purposes, we've created an implementation of `Transport` that lets you create multiple objects that can connect to each other.
With this, you can create a client and a server and test whether they work fine together, without having to open a TCP connection on localhost.

But the question was: which multiaddr should be passed when we "dial" or "listen" on this transport, for which we already known it will be received by the other party?

This PR adds the possibility to have a multiaddr `/memory` (with no parameter), which means that the dialer "magically" knows how to reach the listener.
On the theoretical level, a multiaddress like `/memory/0x14b8a90c` makes sense in my opinion. In practice that would be obviously too unsafe, so we opted for `/memory` alone.