### PR TITLE
Register new address types for Tor and i2p

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -17,8 +17,8 @@ code,	size,	name,		comment
 421,	V,	ipfs,		backwards compatibility; equivalent to /p2p
 444,	96,	onion,
 445,    296, onion3
-446,    276, garlict
-447,    276, garlicu
+446,    3112, garlict
+447,    3112, garlicu
 460,	0,	quic,
 480,	0,	http,
 443,	0,	https,

--- a/protocols.csv
+++ b/protocols.csv
@@ -17,8 +17,8 @@ code,	size,	name,		comment
 421,	V,	ipfs,		backwards compatibility; equivalent to /p2p
 444,	96,	onion,
 445,    296, onion3
-446,    3112, garlict
-447,    3112, garlicu
+446,    3096, garlic64
+447,    256, garlic32
 460,	0,	quic,
 480,	0,	http,
 443,	0,	https,

--- a/protocols.csv
+++ b/protocols.csv
@@ -16,6 +16,9 @@ code,	size,	name,		comment
 421,	V,	p2p,		preferred over /ipfs
 421,	V,	ipfs,		backwards compatibility; equivalent to /p2p
 444,	96,	onion,
+445,    296, onion3
+446,    276, garlict
+447,    276, garlicu
 460,	0,	quic,
 480,	0,	http,
 443,	0,	https,

--- a/protocols.csv
+++ b/protocols.csv
@@ -17,7 +17,7 @@ code,	size,	name,		comment
 421,	V,	ipfs,		backwards compatibility; equivalent to /p2p
 444,	96,	onion,
 445,    296, onion3
-446,    3096, garlic64
+446,    V, garlic64
 460,	0,	quic,
 480,	0,	http,
 443,	0,	https,

--- a/protocols.csv
+++ b/protocols.csv
@@ -18,7 +18,6 @@ code,	size,	name,		comment
 444,	96,	onion,
 445,    296, onion3
 446,    3096, garlic64
-447,    256, garlic32
 460,	0,	quic,
 480,	0,	http,
 443,	0,	https,


### PR DESCRIPTION
I hope I am doing this in the right order. I have a branch of go-multiaddr over here https://github.com/RTradeLtd/go-multiaddr where I've been experimenting with onionv3 and i2p base64 addresses. They are working nicely and I have integrated them into the tests, now I believe I need to register the protocols before I can begin upstreaming them.