### PR TITLE
fix udp code

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -1,7 +1,7 @@
 code,	size,	name,		comment
 4,	32,	ip4,
 6,	16,	tcp,
-17,	16,	udp,
+273,	16,	udp,
 33,	16,	dccp,
 41,	128,	ip6,
 42,	V,	ip6zone,	rfc4007 IPv6 zone


### PR DESCRIPTION
This was changed ages ago but not updated here. The current code *here*
conflicts with SHA1 (in the multicodec table).

Ideally, we wouldn't duplicate these tables but *this* table lists *sizes*. We
could also just remove the numbers from this table and *only* list names/sizes
but we can do that later.