### PR TITLE
add swarm as protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ TODO: most of these are way underspecified
 - /p2p-webrtc-star, /p2p-webrtc-direct
 - /p2p-websocket-star
 - /onion
+- /swarm
 
 
 ## Implementations

--- a/protocols.csv
+++ b/protocols.csv
@@ -15,6 +15,7 @@ code,	size,	name,		comment
 400,	V,	unix,
 421,	V,	p2p,		preferred over /ipfs
 421,	V,	ipfs,		backwards compatibility; equivalent to /p2p
+422,	V,	swarm,
 444,	96,	onion,
 460,	0,	quic,
 480,	0,	http,


### PR DESCRIPTION
Greetings,

This PR adds Swarm as a `multiaddr` recognisable protocol after discussion on [EIP-1577](https://ethereum-magicians.org/t/eip1577-multiaddr-support-for-ens/1969) and [EIP-1062](https://ethereum-magicians.org/t/eip-1062-formalize-ipfs-hash-into-ens-ethereum-name-service-resolver/281).

Thank you <3