### PR TITLE
Add comma to properly format CSV

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -16,7 +16,7 @@ code,	size,	name,		comment
 421,	V,	p2p,		preferred over /ipfs
 421,	V,	ipfs,		backwards compatibility; equivalent to /p2p
 444,	96,	onion,
-445,    296, onion3
+445,    296, onion3,
 446,    V, garlic64
 460,	0,	quic,
 480,	0,	http,


### PR DESCRIPTION
The `onion3` row didn't end with a comma so the CSV wasn't technically formatted properly. This should fix that.