### PR TITLE
add garlic32 addresses

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -18,6 +18,7 @@ code,	size,	name,	comment
 444,	96,	onion,
 445,	296,	onion3,
 446,	V,	garlic64,
+447,	V,	garlic32,
 460,	0,	quic,
 480,	0,	http,
 443,	0,	https,


### PR DESCRIPTION
I now need to use multiaddr to keep track of i2p base32 addresses, so I've added them to the go library to be compatible with the current b32.i2p specification and to handle the near-future base32 for encrypted leasesets specification. I just used the next sequential number after garlic64.