### PR TITLE
Make memory transport length-prefixed

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -29,4 +29,4 @@ code,	size,	name,	comment
 275,	0,	p2p-webrtc-star,
 276,	0,	p2p-webrtc-direct,
 290,	0,	p2p-circuit,
-777,	64, memory, in memory transport for self-dialing and testing; uint64
+777,	V, memory, in memory transport for self-dialing and testing; arbitrary 


### PR DESCRIPTION
Apologies for the sloppiness, eager to get this going. I think for the golang implementation these bytes will be interpreted as a uint64.