### PR TITLE
Added some i2p related address

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -29,4 +29,8 @@ code,	size,	name,	comment
 275,	0,	p2p-webrtc-star,
 276,	0,	p2p-webrtc-direct,
 290,	0,	p2p-circuit,
-777,	V, memory, in memory transport for self-dialing and testing; arbitrary 
+510,	2,	bob
+515,	2,	sam1
+516,	2,	sam2
+517,	3,	sam3
+777,	V,	memory,	in memory transport for self-dialing and testing; arbitrary 

--- a/protocols.csv
+++ b/protocols.csv
@@ -29,8 +29,9 @@ code,	size,	name,	comment
 275,	0,	p2p-webrtc-star,
 276,	0,	p2p-webrtc-direct,
 290,	0,	p2p-circuit,
-510,	2,	bob
-515,	2,	sam1
-516,	2,	sam2
-517,	3,	sam3
+510,	V,	bob,
+515,	V,	sam, this type is an abstraction of all version of sam and should try the latest one to the oldest one until he find one working (or use any autonegociation protocol)
+516,	V,	sam1,
+517,	V,	sam2,
+518,	V,	sam3,
 777,	V,	memory,	in memory transport for self-dialing and testing; arbitrary 

--- a/protocols.csv
+++ b/protocols.csv
@@ -19,6 +19,8 @@ code,	size,	name,	comment
 445,	296,	onion3,
 446,	V,	garlic64,
 447,	V,	garlic32,
+448,	0,	i2p-streaming, an I2P tcp like
+449,	0,	i2p-datagrams, an I2P udp like
 460,	0,	quic,
 480,	0,	http,
 443,	0,	https,
@@ -30,7 +32,7 @@ code,	size,	name,	comment
 276,	0,	p2p-webrtc-direct,
 290,	0,	p2p-circuit,
 510,	V,	bob,
-515,	V,	sam, this type is an abstraction of all version of sam and should try the latest one to the oldest one until he find one working (or use any autonegociation protocol)
+515,	V,	sam, this type is an abstraction of all version of sam, the transport must find one working
 516,	V,	sam1,
 517,	V,	sam2,
 518,	V,	sam3,


### PR DESCRIPTION
You can find the description of how i2p address works here https://geti2p.net/en/docs/naming.
Bob, samX must be over udp or tcp address.
I think it can be used like that :
First listen on a i2p gateway :
```
/ip((4/<gateway ip, usually 127.0.0.1>)|(6/<gateway ip, usually ::1>))/((tcp)|(udp))/<port>/((bob)|(sam[1-3]))/<upstream hops 0-7>,<downstream hops 0-7>,<upstream tunnels 1-6>,<downstream tunnels 1-6>,<Upstream alterator -1 to 2>,<Downstream alterator -1 to 2>,([bds]|(both)|(datagrams)|(streaming))
```
There is 2 protocol, bob and sam, sam3 is the best of all (it have a lot of good idea of bob but multiplexed), bob is for more edge case and older version of sam are here if your node doesn't support newer one.

Upstream and Downstream hops is the number of relay to the rendez-vous (0 is a good choice if you are also serving on non anonymized network (0 disable anonymity but greatly improve speed, useful for providing an i2p to internet node), else 3 is a standard but this choice is yours) range is 0-7 (in i2p but maybe raise in future).
Tunnels count range is 1-6, limited by i2p can maybe be raised (with cpu performance at cost but higher multiple bandwidth), need test to about possible raising.
Upstream and Downstream alterator is of how many hops the tunnel must be randomly altered. All positive number are number of more hops added. So for 3 hops and 2 alteration the number of hops will be randomly between 3-5 (included) hops. For negative one that 2 directional, so 3 hops and -1 alterator the random will choose one between 2-4 (included) hops. This one is very limited is extremely dangerous if you do an error (but still proposed by i2p), also these kind of Multiaddrs will be encoded (and reprinted) as 2 hops and 2 alterator (which is totally the same).
Datagrams and Streaming are i2p version of udp and tcp, and that simply indicate if the bridge should listen on them (both or b for both, datagrams or b for udp like, streaming or s for tcp like).

The encoded version could looks like this :


|    varuint     |     varuint      |        varuint         |         varuint          |       3 bits       |        3 bits        |        1 bits        |        1 bits        |
|---------------|-----------------|-----------------------|-------------------------|--------------------|----------------------|----------------------|----------------------|
| Upstream hops | Downstream hops | Upstream tunnel count | Downstream tunnel count | Upstream alterator | Downstream alterator | Datagrams Flag | Streaming Flag

Alterator are 3 bits uint and need to be converted if -1 is putted.

And connection could be done for `garlic*` address reusing an instancied sam or bob transport (maybe with an integrated nodes in the future).

PS: I've discover after that alterator is a word not existing in english sorry. So here I use as the word alterateur in french (wich doesn't have an "official" validation but works in real life), this means the one that alter.