### PR TITLE
Add Swift client to list of multiaddr implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ TODO: most of these are way underspecified
 - [rust-multiaddr](https://github.com/multiformats/rust-multiaddr) - beta
 - [cs-multiaddress](https://github.com/multiformats/cs-multiaddress) - alpha
 - [net-ipfs-core](https://github.com/richardschneider/net-ipfs-core) - stable
+- [swift-multiaddr](https://github.com/lukereichold/swift-multiaddr) - stable
 
 TODO: reconsider these alpha/beta/stable labels
 


### PR DESCRIPTION
I've written a `multiaddr` client in Swift. As compared to the [existing client](https://github.com/multiformats/SwiftMultiaddr), this version (https://github.com/lukereichold/swift-multiaddr) offers the following:

 * Swift Package Manager (SPM) support
* Written in modern, idiomatic Swift
* Eliminates need for external dependencies
* Greater protocol support

Thanks!