### PR TITLE
Implemented Elixir Multiaddr

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ TODO: most of these are way underspecified
 - [cs-multiaddress](https://github.com/multiformats/cs-multiaddress) - alpha
 - [net-ipfs-core](https://github.com/richardschneider/net-ipfs-core) - stable
 - [swift-multiaddr](https://github.com/lukereichold/swift-multiaddr) - stable
+- [elixir-multiaddr](https://github.com/aratz-lasa/ex_multiaddr) - alpha
 
 TODO: reconsider these alpha/beta/stable labels
 


### PR DESCRIPTION
I have implemented Multiaddr in Elixir. 

- In Github: https://github.com/aratz-lasa/ex_multiaddr
- In Mix: https://hex.pm/packages/ex_multiaddr 

I do not know if I have to do something special or just say it here.
Does it need to be published on the official Multiformats repository (https://github.com/multiformats )? How does it work?