### PR TITLE
Add proxying protocols (SOCKS4/SOCKS4a, SOCKS5 and HTTP tunneling)

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -24,6 +24,9 @@ code,	size,	name,	comment
 443,	0,	https,
 477,	0,	ws,
 478,	0,	wss,
+481,	0,	socks4,	"SOCKS4 proxy, including the SOCKS4a domain name addressing variant (https://www.openssh.com/txt/socks4a.protocol)"
+482,	0,	socks5,	SOCKS5 proxy (RFC1928)
+483,	0,	http-tunnel,	HTTP tunneling proxy (RFC7231#4.3.6); combine with /tls for HTTPS proxies
 479,	0,	p2p-websocket-star,
 277,	0,	p2p-stardust,
 275,	0,	p2p-webrtc-star,


### PR DESCRIPTION
Needed for adding proxy support to py-ipfs-api-client.