### PR TITLE
Add ipcidr

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ and [protocols/](protocols/) for specifications of the currently supported proto
 TODO: most of these are way underspecified
 
 - /ip4, /ip6
+- /ipcidr
 - /dns4, /dns6
 - [/dnsaddr](protocols/DNSADDR.md)
 - /tcp

--- a/protocols.csv
+++ b/protocols.csv
@@ -5,6 +5,7 @@ code,	size,	name,	comment
 33,	16,	dccp,
 41,	128,	ip6,
 42,	V,	ip6zone,	rfc4007 IPv6 zone
+43,	8,	ipcidr, CIDR mask for IP addresses
 53,	V,	dns,  domain name resolvable to both IPv6 and IPv4 addresses
 54,	V,	dns4, domain name resolvable only to IPv4 addresses
 55,	V,	dns6, domain name resolvable only to IPv6 addresses


### PR DESCRIPTION
Adds ipcidr to multiaddr. See https://github.com/multiformats/go-multiaddr/pull/177 for the Go implementation.

## Why

We want to be able to specify a set of allowed ip addresses in the resource manager. These addresses will get some special treatment. We want to be able to specify a cidr range of ip addresses, and it's convenient to include this range directly in the multiaddr rather than a separate parameter.


Other use cases:

1. [Go multiaddr dns](https://github.com/multiformats/go-multiaddr-dns) includes a potential example of resolving a dnsaddr and filtering with ipcidr.
1. A node may be listening on a range of addresses (1.2.3.4/31) and can thus compress its multiaddr to a single multiaddr instead of two.


