### PR TITLE
Add SNI to protocols.csv

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -21,6 +21,7 @@ code,	size,	name,	comment
 446,	V,	garlic64,
 447,	V,	garlic32,
 448,	0,	tls,	Transport Layer Security
+449,	V,	sni,	Server Name Indication RFC 6066 § 3
 454,	0,	noise,
 460,	0,	quic,
 465,	0,	webtransport,


### PR DESCRIPTION
This registers the SNI component which can be used by transports to set the sni field in their client hello. See RFC 6066 section 3 for more details.

We need this so that secure websocket clients can know what SNI to send when connecting to an ip address.