### PR TITLE
Add SRV protocol

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -37,3 +37,4 @@ code,	size,	name,	comment
 280,	0,	webrtc, ICE-lite webrtc transport
 290,	0,	p2p-circuit,
 777,	V, memory, in memory transport for self-dialing and testing; arbitrary 
+2782, V, srv, See RFC 2782 (format: /srv/<servicename>/<tcp/udp/protocol>/<domain>, example: /srv/coolservice/tcp/domain.example.com)

--- a/protocols.csv
+++ b/protocols.csv
@@ -37,4 +37,4 @@ code,	size,	name,	comment
 280,	0,	webrtc, ICE-lite webrtc transport
 290,	0,	p2p-circuit,
 777,	V, memory, in memory transport for self-dialing and testing; arbitrary 
-2782, V, srv, See RFC 2782 (format: /srv/<servicename>/<tcp/udp/protocol>/<domain>, example: /srv/coolservice/tcp/domain.example.com)
+2782, V,  srv, DNS SRV Record (See RFC 2782, format: /srv/<servicename>/<tcp/udp/protocol>/<domain>, example: /srv/coolservice/tcp/domain.example.com)


### PR DESCRIPTION
## Summary

Adds a new multiaddr protocol for SRV DNS records (see RFC 2782).

## Before Merge

- [ ] Allow at least 24 hours for community input
- [ ] If this is a new protocol, has the change been applied to https://github.com/multiformats/multicodec as well? If so, please [link the multicodec PR](https://github.com/multiformats/multicodec/pull/295).
