### PR TITLE
Add host-header to protocol.csv

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -26,6 +26,7 @@ code,	size,	name,	comment
 460,	0,	quic,
 465,	0,	webtransport,
 466,    V,	certhash,
+481,  V,  host-header, HTTP host header
 480,	0,	http,	HyperText Transfer Protocol
 443,	0,	https,	Deprecated alias for /tls/http
 477,	0,	ws,	WebSockets


### PR DESCRIPTION
Host header is required for HTTP based protocol (HTTP, HTTPS, WS, WSS) when DNS(, 4, 6, addr) has been resolved to an IP address and TCP port.

This is required to preserve the host header while resolving a DNS address. The tuple ip:port alone is not sufficient to contact a host via HTTP.

For instance, this is going to be used to address libp2p/go-libp2p#1829

cc @MarcoPolo 
