### PR TITLE
fix: Rename webrtc-w3c to webrtc and webrtc to webrtc-direct

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -35,7 +35,7 @@ code,	size,	name,	comment
 277,	0,	p2p-stardust,
 275,	0,	p2p-webrtc-star,
 276,	0,	p2p-webrtc-direct,
-280,	0,	webrtc, ICE-lite webrtc transport
-281, 	0,	webrtc-w3c, webrtc transport where connection establishment is according to w3c spec
+280,	0,	webrtc-direct, ICE-lite webrtc transport with SDP munging during connection establishment and without use of a STUN server
+281, 	0,	webrtc, webrtc transport where connection establishment is according to w3c spec
 290,	0,	p2p-circuit,
 777,	V, memory, in memory transport for self-dialing and testing; arbitrary 


### PR DESCRIPTION
## Summary

Following on from https://github.com/multiformats/multiaddr/pull/150 and a replacement for https://github.com/multiformats/multiaddr/pull/151

Renames:

- `/webrtc-w3c` -> `/webrtc` - AKA browser to browser
- `/webrtc` -> `/webrtc-direct` - AKA browser to server

Discussion:

- This option was mentioned in #150 and seemed to have a reasonable amount of support but seemed to get lost amongst the other options
- The differences in the protocols is mentioned in the table comments

## Before Merge
<!-- Anything that's needed before we merge this? -->
- [ ] Allow at least 24 hours for community input
- [ ] If this is a new protocol, has the change been applied to https://github.com/multiformats/multicodec as well? If so, please link the multicodec PR.
