### PR TITLE
fix: Rename webrtc-w3c to webrtc and webrtc to webrtc+sdp-munging

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -35,7 +35,7 @@ code,	size,	name,	comment
 277,	0,	p2p-stardust,
 275,	0,	p2p-webrtc-star,
 276,	0,	p2p-webrtc-direct,
-280,	0,	webrtc, ICE-lite webrtc transport
-281, 	0,	webrtc-w3c, webrtc transport where connection establishment is according to w3c spec
+280,	0,	webrtc+sdp-munging, ICE-lite webrtc transport with SDP munging during connection establishment and without use of a STUN server
+281, 	0,	webrtc, webrtc transport where connection establishment is according to w3c spec
 290,	0,	p2p-circuit,
 777,	V, memory, in memory transport for self-dialing and testing; arbitrary 


### PR DESCRIPTION
## Summary

Following on from https://github.com/multiformats/multiaddr/pull/150 and an replacement for https://github.com/multiformats/multiaddr/pull/151

Renames:

- `/webrtc-w3c` -> `/webrtc` - AKA browser to browser
- `/webrtc` -> `/webrtc+sdp-munging` - AKA browser to server

Discussion:

- This option comes from comments on https://github.com/multiformats/multiaddr/pull/151
- It got a lukewarm reception on the triage call so it's presented as an option along with https://github.com/multiformats/multiaddr/pull/152
- Adding `+sdp-munging` makes it more explicit about the differences, though admittedly there are other differences that aren't encapsulated in the name
- People were uncertain about universal understanding of the term "SDP munging"

## Before Merge
<!-- Anything that's needed before we merge this? -->
- [ ] Allow at least 24 hours for community input
- [ ] If this is a new protocol, has the change been applied to https://github.com/multiformats/multicodec as well? If so, please link the multicodec PR.
