### PR TITLE
Define `/httppath`

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -28,6 +28,7 @@ code,	size,	name,	comment
 465,	0,	webtransport,
 466,	V,	certhash,
 480,	0,	http,	HyperText Transfer Protocol
+481,	V,	httppath,	Percent-encoded path to an HTTP resource
 443,	0,	https,	Deprecated alias for /tls/http
 477,	0,	ws,	WebSockets
 478,	0,	wss,	Deprecated alias for /tls/ws

--- a/protocols/httppath.md
+++ b/protocols/httppath.md
@@ -1,0 +1,40 @@
+# `httppath`
+
+This protocol encodes an HTTP Path to a resource. In the string representation,
+characters in the reserved set are percent-encoded ( "/" becomes "%2F").
+Percent-encoding itself is defined by [RFC 3986 Section
+2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1). In the binary representation, no escaping is needed as the value is length prefixed.
+
+To ease implementation and benefit from reusing existing percent-encoding logic
+present in many environments (Go's
+[url.PathEscape](https://pkg.go.dev/net/url@go1.21.0#PathEscape); JS's
+[encodeURIComponent](http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent);
+and Rust's [many
+crates](https://crates.io/search?q=percent%20encode&sort=downloads)), it is
+acceptable to encode more characters than the reserved set. While it's not
+necessary to encode a space " " as %20, it's is acceptable to do so.
+
+When comparing multiaddrs, implementations should compare their binary
+representation to avoid ambiguities over which characters were escaped.
+
+## Reserved Characters
+
+| Character | Reason                        |
+| --------- | ----------------------------- |
+| /         | Multiaddr component separator |
+| %         | Percent encoding indicator    |
+| ?         | Marks the end of an HTTP path |
+
+## Usage
+
+`/httppath` should be appended to the end of an existing multiaddr, including after the peer id component (p2p). As an example, here's a multiaddr referencing the `.well-known/libp2p` HTTP resource along with a way to reach that peer:
+
+```
+/ip4/1.2.3.4/tcp/443/tls/http/p2p/12D.../httppath/.well-known%2Flibp2p
+```
+
+The `/httppath` component can also be appended to just the `/p2p/...` component, and rely on a separate peer discovery mechanism to actually identify the peer's address:
+
+```
+/ip4/1.2.3.4/tcp/443/tls/http/p2p/12D.../httppath/.well-known%2Flibp2p
+```


### PR DESCRIPTION
## Summary

Adds a new multiaddr component for `/httppath`, and define it.

I think this follows RFC 3986's notion of "Path" (section [3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3)). Please correct me if I'm wrong.

I'm using `httppath` instead of `httpath` (used by IPNI) previously for two reasons:

1. I prefer joining two full words.
2. In case there's any conflicting interpretation, this will be unambiguous as it has a different name. 

## Before Merge
<!-- Anything that's needed before we merge this? -->
- [ ] Allow at least 24 hours for community input
- [ ] If this is a new protocol, has the change been applied to https://github.com/multiformats/multicodec as well? If so, please link the multicodec PR.


