### PR TITLE
chore: improve `dns` description to match actual implementations

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -6,7 +6,7 @@ code,	size,	name,	comment
 41,	128,	ip6,
 42,	V,	ip6zone,	rfc4007 IPv6 zone
 43,	8,	ipcidr, CIDR mask for IP addresses
-53,	V,	dns,  domain name resolvable to both IPv6 and IPv4 addresses
+53,	V,	dns,  domain name resolvable to IPv4 or IPv6 addresses
 54,	V,	dns4, domain name resolvable only to IPv4 addresses
 55,	V,	dns6, domain name resolvable only to IPv6 addresses
 56,	V,	dnsaddr,


### PR DESCRIPTION
## Summary
<!-- What's the change? -->
I believe the proposed wording better matches the reality, as the address does not strictly need to resolve to both IPv4 and IPv6 - only one of them. In `rust-libp2p` this is achieved via [dual DNS lookup](https://github.com/hickory-dns/hickory-dns/blob/02a8668fd54be5c3b1a9f8d8e79393229ffea2be/crates/resolver/src/async_resolver.rs#L375). `go-libp2p` should also handle that.

Case - Filecoin bootstrap nodes https://github.com/ChainSafe/forest/pull/4438 and a corresponding https://github.com/filecoin-project/lotus/commit/893ce8e98d03672f0eb75b462256eb6a36021ded

```
❯ host -t A calibration.node.glif.io
calibration.node.glif.io is an alias for a2ad5f028b78e4f628b8280d2482e5fa-9805736762487b63.elb.ap-northeast-1.amazonaws.com.
a2ad5f028b78e4f628b8280d2482e5fa-9805736762487b63.elb.ap-northeast-1.amazonaws.com has address 13.112.175.23

❯ host -t AAAA calibration.node.glif.io
calibration.node.glif.io is an alias for a2ad5f028b78e4f628b8280d2482e5fa-9805736762487b63.elb.ap-northeast-1.amazonaws.com.

❯ host -t AAAA a2ad5f028b78e4f628b8280d2482e5fa-9805736762487b63.elb.ap-northeast-1.amazonaws.com.
a2ad5f028b78e4f628b8280d2482e5fa-9805736762487b63.elb.ap-northeast-1.amazonaws.com has no AAAA record

❯ host -t AAAA bootstrap-calibnet-2.chainsafe-fil.io
bootstrap-calibnet-2.chainsafe-fil.io has IPv6 address 2001:41d0:306:44db::

❯ host -t A bootstrap-calibnet-2.chainsafe-fil.io
bootstrap-calibnet-2.chainsafe-fil.io has address 135.125.74.219
```

## Before Merge
<!-- Anything that's needed before we merge this? -->
- [x] Allow at least 24 hours for community input
- [ ] If this is a new protocol, has the change been applied to https://github.com/multiformats/multicodec as well? If so, please link the multicodec PR.
